### PR TITLE
Fixed code issues. Added all working charsets to WellKnownCharsets and made overloaded function with string argument private

### DIFF
--- a/res/controllers/engine-api.d.ts
+++ b/res/controllers/engine-api.d.ts
@@ -308,7 +308,116 @@ declare namespace engine {
         Latin9,
         ISO_8859_15,
         UCS2,
-        ISO_10646_UCS_2
+        ISO_10646_UCS_2,
+        UTF_8,
+        UTF_16,
+        UTF_16BE,
+        UTF_16LE,
+        UTF_32,
+        UTF_32BE,
+        UTF_32LE,
+        UTF_16BE_Version_1,
+        UTF_16LE_Version_1,
+        UTF_16_Version_1,
+        UTF_16_Version_2,
+        UTF_7,
+        SCSU,
+        BOCU_1,
+        CESU_8,
+        US_ASCII,
+        GB18030,
+        ISO_8859_2,
+        ISO_8859_3,
+        ISO_8859_4,
+        ISO_8859_5,
+        ISO_8859_6,
+        ISO_8859_7,
+        ISO_8859_8,
+        ISO_8859_9,
+        ISO_8859_10,
+        ISO_8859_13,
+        ISO_8859_14,
+        Shift_JIS,
+        EUC_JP,
+        Big5,
+        Big5_HKSCS,
+        GBK,
+        GB2312,
+        EUC_KR,
+        CP1363,
+        KSC_5601,
+        Windows_874_2000,
+        TIS_620,
+        IBM437, /** OEM United States */
+        IBM775, /** OEM Baltic */
+        IBM850, /** OEM Multilingual Latin 1 */
+        CP851,
+        IBM852, /** OEM Latin 2 */
+        IBM855, /** OEM Cyrillic */
+        IBM857, /** OEM Turkish */
+        IBM00858, /** OEM Multilingual Latin 1 + Euro symbol */
+        IBM860, /** OEM Portuguese */
+        IBM861, /** OEM Icelandic */
+        IBM862, /** OEM Hebrew */
+        IBM863, /** OEM Canadian French */
+        IBM864, /** OEM Arabic */
+        IBM865, /** OEM Nordic */
+        IBM866, /** OEM Russian */
+        IBM868, /** OEM Arabic */
+        IBM869, /** OEM Greek */
+        KOI8_R, /** KOI8-R */
+        KOI8_U, /** KOI8-U */
+        Windows_1250, /** Windows Central Europe */
+        Windows_1251, /** Windows Cyrillic */
+        Windows_1252, /** Windows Latin 1 */
+        Windows_1253, /** Windows Greek */
+        Windows_1254, /** Windows Turkish */
+        Windows_1255, /** Windows Hebrew */
+        Windows_1256, /** Windows Arabic */
+        Windows_1257, /** Windows Baltic */
+        Windows_1258, /** Windows Vietnamese */
+        Macintosh,
+        X_Mac_Greek,
+        X_Mac_Cyrillic,
+        X_Mac_CentralEuroRoman,
+        X_Mac_Turkish,
+        HP_Roman8,
+        Adobe_Standard_Encoding,
+        ISO_2022_JP,
+        ISO_2022_JP_1,
+        ISO_2022_JP_2,
+        ISO_2022_KR,
+        ISO_2022_CN,
+        ISO_2022_CN_EXT,
+        HZ_GB_2312,
+        IBM037, /** IBM EBCDIC US-Canada */
+        IBM273, /** IBM EBCDIC Germany */
+        IBM277, /** IBM EBCDIC Denmark-Norway */
+        IBM278, /** IBM EBCDIC Finland-Sweden */
+        IBM280, /** IBM EBCDIC Italy */
+        IBM284, /** IBM EBCDIC Latin America-Spain */
+        IBM285, /** IBM EBCDIC United Kingdom */
+        IBM290, /** IBM EBCDIC Japanese Katakana Extended */
+        IBM297, /** IBM EBCDIC France */
+        IBM420, /** IBM EBCDIC Arabic */
+        IBM424, /** IBM EBCDIC Hebrew */
+        IBM500, /** IBM EBCDIC International */
+        IBM_Thai,
+        IBM870, /** IBM EBCDIC Multilingual Latin 2 */
+        IBM871, /** IBM EBCDIC Icelandic */
+        IBM918, /** IBM EBCDIC Arabic */
+        IBM1026, /** IBM EBCDIC Turkish Latin 5 */
+        IBM1047, /** IBM EBCDIC Latin 1 Open System */
+        IBM01140, /** IBM EBCDIC US-Canada + Euro symbol */
+        IBM01141, /** IBM EBCDIC Germany + Euro symbol */
+        IBM01142, /** IBM EBCDIC Denmark-Norway + Euro symbol */
+        IBM01143, /** IBM EBCDIC Finland-Sweden + Euro symbol */
+        IBM01144, /** IBM EBCDIC Italy + Euro symbol */
+        IBM01145, /** IBM EBCDIC Latin America-Spain + Euro symbol */
+        IBM01146, /** IBM EBCDIC United Kingdom + Euro symbol */
+        IBM01147, /** IBM EBCDIC France + Euro symbol */
+        IBM01148, /** IBM EBCDIC International + Euro symbol */
+        IBM01149, /** IBM EBCDIC Icelandic + Euro symbol */
     }
 
     /**
@@ -317,14 +426,6 @@ declare namespace engine {
      * This function is useful to display text on a device that does not make use of UTF-8.
      * Available charset names are listed here: http://www.iana.org/assignments/character-sets/character-sets.xhtml.
      * Characters that are unsupported by target charset will be transformed to null character (0x00).
-     * @param targetCharset The charset to encode the string into.
-     * @param value The string to encode
-     * @returns The converted String as an array of bytes. Will return an empty buffer on conversion error.
-     */
-    function convertCharset(targetCharset: string, value: string): ArrayBuffer
-
-    /**
-     * Version of {@link engine.convertCharset} to use with {@link engine.WellKnownCharsets}.
      * @param targetCharset The charset to encode the string into.
      * @param value The string to encode
      * @returns The converted String as an array of bytes. Will return an empty buffer on conversion error.

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.cpp
@@ -7,6 +7,7 @@
 #endif
 #include <gsl/pointers>
 
+#include <QtEndian>
 #include "control/controlobject.h"
 #include "control/controlobjectscript.h"
 #include "control/controlpotmeter.h"
@@ -1059,39 +1060,279 @@ QByteArray ControllerScriptInterfaceLegacy::convertCharset(
     switch (targetCharset) {
     case WellKnownCharsets::Latin1:
     case WellKnownCharsets::ISO_8859_1:
-        return convertCharset(QStringLiteral("ISO-8859-1"), value);
+        return convertCharsetInternal(QStringLiteral("ISO-8859-1"), value);
     case WellKnownCharsets::Latin9:
     case WellKnownCharsets::ISO_8859_15:
-        return convertCharset(QStringLiteral("ISO-8859-15"), value);
+        return convertCharsetInternal(QStringLiteral("ISO-8859-15"), value);
     case WellKnownCharsets::UCS2:
     case WellKnownCharsets::ISO_10646_UCS_2:
-        return convertCharset(QStringLiteral("ISO-10646-UCS-2"), value);
+        return convertCharsetInternal(QStringLiteral("ISO-10646-UCS-2"), value);
+    case WellKnownCharsets::UTF_8:
+        return convertCharsetInternal(QStringLiteral("UTF-8"), value);
+    case WellKnownCharsets::UTF_16:
+        return convertCharsetInternal(QStringLiteral("UTF-16"), value);
+    case WellKnownCharsets::UTF_16BE:
+        return convertCharsetInternal(QStringLiteral("UTF-16BE"), value);
+    case WellKnownCharsets::UTF_16LE:
+        return convertCharsetInternal(QStringLiteral("UTF-16LE"), value);
+    case WellKnownCharsets::UTF_32:
+        return convertCharsetInternal(QStringLiteral("UTF-32"), value);
+    case WellKnownCharsets::UTF_32BE:
+        return convertCharsetInternal(QStringLiteral("UTF-32BE"), value);
+    case WellKnownCharsets::UTF_32LE:
+        return convertCharsetInternal(QStringLiteral("UTF-32LE"), value);
+    case WellKnownCharsets::UTF_7:
+        return convertCharsetInternal(QStringLiteral("UTF-7"), value);
+    case WellKnownCharsets::SCSU:
+        return convertCharsetInternal(QStringLiteral("SCSU"), value);
+    case WellKnownCharsets::BOCU_1:
+        return convertCharsetInternal(QStringLiteral("BOCU-1"), value);
+    case WellKnownCharsets::CESU_8:
+        return convertCharsetInternal(QStringLiteral("CESU-8"), value);
+    case WellKnownCharsets::US_ASCII:
+        return convertCharsetInternal(QStringLiteral("US-ASCII"), value);
+    case WellKnownCharsets::GB18030:
+        return convertCharsetInternal(QStringLiteral("GB18030"), value);
+    case WellKnownCharsets::ISO_8859_2:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-2"), value);
+    case WellKnownCharsets::ISO_8859_3:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-3"), value);
+    case WellKnownCharsets::ISO_8859_4:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-4"), value);
+    case WellKnownCharsets::ISO_8859_5:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-5"), value);
+    case WellKnownCharsets::ISO_8859_6:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-6"), value);
+    case WellKnownCharsets::ISO_8859_7:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-7"), value);
+    case WellKnownCharsets::ISO_8859_8:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-8"), value);
+    case WellKnownCharsets::ISO_8859_9:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-9"), value);
+    case WellKnownCharsets::ISO_8859_10:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-10"), value);
+    case WellKnownCharsets::ISO_8859_13:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-13"), value);
+    case WellKnownCharsets::ISO_8859_14:
+        return convertCharsetInternal(QStringLiteral("ISO-8859-14"), value);
+    case WellKnownCharsets::Shift_JIS:
+        return convertCharsetInternal(QStringLiteral("Shift_JIS"), value);
+    case WellKnownCharsets::EUC_JP:
+        return convertCharsetInternal(QStringLiteral("EUC-JP"), value);
+    case WellKnownCharsets::Big5:
+        return convertCharsetInternal(QStringLiteral("Big5"), value);
+    case WellKnownCharsets::Big5_HKSCS:
+        return convertCharsetInternal(QStringLiteral("Big5-HKSCS"), value);
+    case WellKnownCharsets::GBK:
+        return convertCharsetInternal(QStringLiteral("GBK"), value);
+    case WellKnownCharsets::GB2312:
+        return convertCharsetInternal(QStringLiteral("GB2312"), value);
+      case WellKnownCharsets::EUC_KR:
+        return convertCharsetInternal(QStringLiteral("EUC-KR"), value);
+    case WellKnownCharsets::CP1363:
+        return convertCharsetInternal(QStringLiteral("cp1363"), value);
+    case WellKnownCharsets::KSC_5601:
+        return convertCharsetInternal(QStringLiteral("KSC_5601"), value);
+    case WellKnownCharsets::Windows_874_2000:
+        return convertCharsetInternal(QStringLiteral("windows-874-2000"), value);
+    case WellKnownCharsets::TIS_620:
+        return convertCharsetInternal(QStringLiteral("TIS-620"), value);
+    case WellKnownCharsets::IBM437:
+        return convertCharsetInternal(QStringLiteral("IBM437"), value);
+    case WellKnownCharsets::IBM775:
+        return convertCharsetInternal(QStringLiteral("IBM775"), value);
+    case WellKnownCharsets::IBM850:
+        return convertCharsetInternal(QStringLiteral("IBM850"), value);
+    case WellKnownCharsets::CP851:
+        return convertCharsetInternal(QStringLiteral("cp851"), value);
+    case WellKnownCharsets::IBM852:
+        return convertCharsetInternal(QStringLiteral("IBM852"), value);
+    case WellKnownCharsets::IBM855:
+        return convertCharsetInternal(QStringLiteral("IBM855"), value);
+    case WellKnownCharsets::IBM857:
+        return convertCharsetInternal(QStringLiteral("IBM857"), value);
+    case WellKnownCharsets::IBM00858:
+        return convertCharsetInternal(QStringLiteral("IBM00858"), value);
+    case WellKnownCharsets::IBM860:
+        return convertCharsetInternal(QStringLiteral("IBM860"), value);
+    case WellKnownCharsets::IBM861:
+        return convertCharsetInternal(QStringLiteral("IBM861"), value);
+    case WellKnownCharsets::IBM862:
+        return convertCharsetInternal(QStringLiteral("IBM862"), value);
+    case WellKnownCharsets::IBM863:
+        return convertCharsetInternal(QStringLiteral("IBM863"), value);
+    case WellKnownCharsets::IBM864:
+        return convertCharsetInternal(QStringLiteral("IBM864"), value);
+    case WellKnownCharsets::IBM865:
+        return convertCharsetInternal(QStringLiteral("IBM865"), value);
+    case WellKnownCharsets::IBM866:
+        return convertCharsetInternal(QStringLiteral("IBM866"), value);
+    case WellKnownCharsets::IBM868:
+        return convertCharsetInternal(QStringLiteral("IBM868"), value);
+    case WellKnownCharsets::IBM869:
+        return convertCharsetInternal(QStringLiteral("IBM869"), value);
+    case WellKnownCharsets::KOI8_R:
+        return convertCharsetInternal(QStringLiteral("KOI8-R"), value);
+    case WellKnownCharsets::KOI8_U:
+        return convertCharsetInternal(QStringLiteral("KOI8-U"), value);
+    case WellKnownCharsets::Windows_1250:
+        return convertCharsetInternal(QStringLiteral("windows-1250"), value);
+    case WellKnownCharsets::Windows_1251:
+        return convertCharsetInternal(QStringLiteral("windows-1251"), value);
+    case WellKnownCharsets::Windows_1252:
+        return convertCharsetInternal(QStringLiteral("windows-1252"), value);
+    case WellKnownCharsets::Windows_1253:
+        return convertCharsetInternal(QStringLiteral("windows-1253"), value);
+    case WellKnownCharsets::Windows_1254:
+        return convertCharsetInternal(QStringLiteral("windows-1254"), value);
+    case WellKnownCharsets::Windows_1255:
+        return convertCharsetInternal(QStringLiteral("windows-1255"), value);
+    case WellKnownCharsets::Windows_1256:
+        return convertCharsetInternal(QStringLiteral("windows-1256"), value);
+    case WellKnownCharsets::Windows_1257:
+        return convertCharsetInternal(QStringLiteral("windows-1257"), value);
+    case WellKnownCharsets::Windows_1258:
+        return convertCharsetInternal(QStringLiteral("windows-1258"), value);
+    case WellKnownCharsets::Macintosh:
+        return convertCharsetInternal(QStringLiteral("macintosh"), value);
+    case WellKnownCharsets::X_Mac_Greek:
+        return convertCharsetInternal(QStringLiteral("x-mac-greek"), value);
+    case WellKnownCharsets::X_Mac_Cyrillic:
+        return convertCharsetInternal(QStringLiteral("x-mac-cyrillic"), value);
+    case WellKnownCharsets::X_Mac_CentralEuroRoman:
+        return convertCharsetInternal(QStringLiteral("x-mac-centraleurroman"), value);
+    case WellKnownCharsets::X_Mac_Turkish:
+        return convertCharsetInternal(QStringLiteral("x-mac-turkish"), value);
+    case WellKnownCharsets::HP_Roman8:
+        return convertCharsetInternal(QStringLiteral("hp-roman8"), value);
+    case WellKnownCharsets::Adobe_Standard_Encoding:
+        return convertCharsetInternal(QStringLiteral("Adobe-Standard-Encoding"), value);
+    case WellKnownCharsets::ISO_2022_JP:
+        return convertCharsetInternal(QStringLiteral("ISO-2022-JP"), value);
+    case WellKnownCharsets::ISO_2022_JP_1:
+        return convertCharsetInternal(QStringLiteral("ISO-2022-JP-1"), value);
+    case WellKnownCharsets::ISO_2022_JP_2:
+        return convertCharsetInternal(QStringLiteral("ISO-2022-JP-2"), value);
+    case WellKnownCharsets::ISO_2022_KR:
+        return convertCharsetInternal(QStringLiteral("ISO-2022-KR"), value);
+    case WellKnownCharsets::ISO_2022_CN:
+        return convertCharsetInternal(QStringLiteral("ISO-2022-CN"), value);
+    case WellKnownCharsets::ISO_2022_CN_EXT:
+        return convertCharsetInternal(QStringLiteral("ISO-2022-CN-EXT"), value);
+    case WellKnownCharsets::HZ_GB_2312:
+        return convertCharsetInternal(QStringLiteral("HZ-GB-2312"), value);
+    case WellKnownCharsets::IBM037:
+        return convertCharsetInternal(QStringLiteral("IBM037"), value);
+    case WellKnownCharsets::IBM273:
+        return convertCharsetInternal(QStringLiteral("IBM273"), value);
+    case WellKnownCharsets::IBM277:
+        return convertCharsetInternal(QStringLiteral("IBM277"), value);
+    case WellKnownCharsets::IBM278:
+        return convertCharsetInternal(QStringLiteral("IBM278"), value);
+    case WellKnownCharsets::IBM280:
+        return convertCharsetInternal(QStringLiteral("IBM280"), value);
+    case WellKnownCharsets::IBM284:
+        return convertCharsetInternal(QStringLiteral("IBM284"), value);
+    case WellKnownCharsets::IBM285:
+        return convertCharsetInternal(QStringLiteral("IBM285"), value);
+    case WellKnownCharsets::IBM290:
+        return convertCharsetInternal(QStringLiteral("IBM290"), value);
+    case WellKnownCharsets::IBM297:
+        return convertCharsetInternal(QStringLiteral("IBM297"), value);
+    case WellKnownCharsets::IBM420:
+        return convertCharsetInternal(QStringLiteral("IBM420"), value);
+    case WellKnownCharsets::IBM424:
+        return convertCharsetInternal(QStringLiteral("IBM424"), value);
+    case WellKnownCharsets::IBM500:
+        return convertCharsetInternal(QStringLiteral("IBM500"), value);
+    case WellKnownCharsets::IBM_Thai:
+        return convertCharsetInternal(QStringLiteral("IBM-Thai"), value);
+    case WellKnownCharsets::IBM870:
+        return convertCharsetInternal(QStringLiteral("IBM870"), value);
+    case WellKnownCharsets::IBM871:
+        return convertCharsetInternal(QStringLiteral("IBM871"), value);
+    case WellKnownCharsets::IBM918:
+        return convertCharsetInternal(QStringLiteral("IBM918"), value);
+    case WellKnownCharsets::IBM1026:
+        return convertCharsetInternal(QStringLiteral("IBM1026"), value);
+    case WellKnownCharsets::IBM1047:
+        return convertCharsetInternal(QStringLiteral("IBM1047"), value);
+    case WellKnownCharsets::IBM01140:
+        return convertCharsetInternal(QStringLiteral("IBM01140"), value);
+    case WellKnownCharsets::IBM01141:
+        return convertCharsetInternal(QStringLiteral("IBM01141"), value);
+    case WellKnownCharsets::IBM01142:
+        return convertCharsetInternal(QStringLiteral("IBM01142"), value);
+    case WellKnownCharsets::IBM01143:
+        return convertCharsetInternal(QStringLiteral("IBM01143"), value);
+    case WellKnownCharsets::IBM01144:
+        return convertCharsetInternal(QStringLiteral("IBM01144"), value);
+    case WellKnownCharsets::IBM01145:
+        return convertCharsetInternal(QStringLiteral("IBM01145"), value);
+    case WellKnownCharsets::IBM01146:
+        return convertCharsetInternal(QStringLiteral("IBM01146"), value);
+    case WellKnownCharsets::IBM01147:
+        return convertCharsetInternal(QStringLiteral("IBM01147"), value);
+    case WellKnownCharsets::IBM01148:
+        return convertCharsetInternal(QStringLiteral("IBM01148"), value);
+    case WellKnownCharsets::IBM01149:
+        return convertCharsetInternal(QStringLiteral("IBM01149"), value);
     default:
         m_pScriptEngineLegacy->logOrThrowError(QStringLiteral("Unknown charset specified"));
         return QByteArray();
     }
 }
 
-QByteArray ControllerScriptInterfaceLegacy::convertCharset(
-        const QString& targetCharset, const QString& value) {
-    QByteArray encoderNameArray = targetCharset.toUtf8();
 #if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+// Add Byte Order Mark (BOM) to the beginning of the data if it is not already present
+static QByteArray addBom(const QByteArray& data) {
+    static const QByteArray bomBE = QByteArray::fromHex("FEFF");
+    static const QByteArray bomLE = QByteArray::fromHex("FFFE");
+
+    // Check system endianness
+    if (QSysInfo::ByteOrder == QSysInfo::BigEndian) {
+        if (!data.startsWith(bomBE)) {
+            return bomBE + data;
+        }
+    } else {
+        if (!data.startsWith(bomLE)) {
+            return bomLE + data;
+        }
+    }
+    return data;
+}
+#endif
+
+QByteArray ControllerScriptInterfaceLegacy::convertCharsetInternal(
+        const QString& targetCharset, const QString& value) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 4, 0)
+    QByteArray encoderNameArray = targetCharset.toUtf8();
     auto* pCodec = QTextCodec::codecForName(encoderNameArray);
     if (!pCodec) {
-        m_pScriptEngineLegacy->logOrThrowError(QStringLiteral("Unable to open encoder"));
+        m_pScriptEngineLegacy->logOrThrowError(
+                QStringLiteral("Unable to get QTextCodec name for charset: %1").arg(targetCharset));
         return QByteArray();
     }
-    return pCodec->makeEncoder(QTextCodec::Flag::ConvertInvalidToNull)->fromUnicode(value);
+    std::unique_ptr<QTextEncoder> encoder(
+            pCodec->makeEncoder(QTextCodec::Flag::ConvertInvalidToNull));
+    if (encoderNameArray == "ISO-10646-UCS-2" || encoderNameArray == "UCS2") {
+        // For these encodings QTextCodec does not set, the BOM which QStringEncoder does
+        return addBom(encoder->fromUnicode(value));
+    }
+    return encoder->fromUnicode(value);
+
 #else
 #if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
-    QAnyStringView encoderName = QAnyStringView(encoderNameArray);
+    QAnyStringView encoderName = QAnyStringView(targetCharset);
 #else
+    QByteArray encoderNameArray = targetCharset.toUtf8();
     const char* encoderName = encoderNameArray.constData();
 #endif
     QStringEncoder fromUtf16 = QStringEncoder(
             encoderName, QStringEncoder::Flag::ConvertInvalidToNull);
     if (!fromUtf16.isValid()) {
-        m_pScriptEngineLegacy->logOrThrowError(QStringLiteral("Unable to open encoder"));
+        m_pScriptEngineLegacy->logOrThrowError(
+                QStringLiteral("Unable to open encoder for charset: %1").arg(targetCharset));
         return QByteArray();
     }
     return fromUtf16(value);

--- a/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
+++ b/src/controllers/scripting/legacy/controllerscriptinterfacelegacy.h
@@ -23,8 +23,244 @@ class ControllerScriptInterfaceLegacy : public QObject {
         Latin9,
         ISO_8859_15,
         UCS2,
-        ISO_10646_UCS_2
+        ISO_10646_UCS_2,
+        UTF_8,
+        UTF_16,
+        UTF_16BE,
+        UTF_16LE,
+        UTF_32,
+        UTF_32BE,
+        UTF_32LE,
+        /* Platform endianness is not supported by QTextCodec
+        * and is not relevant for controller scripting
+        * as the host computer platform is not the target
+        UTF16_PlatformEndian,
+        UTF16_OppositeEndian,
+        UTF32_PlatformEndian,
+        UTF32_OppositeEndian,*/
+        // UTF_16BE_Version_1, // Not supported by QTextCodec
+        // UTF_16LE_Version_1, // Not supported by QTextCodec
+        // UTF_16_Version_1,   // Not supported by QTextCodec
+        // UTF_16_Version_2,   // Not supported by QTextCodec
+        UTF_7,
+        // IMAP_Mailbox_Name,  // Not supported by QTextCodec
+        SCSU,
+        BOCU_1,
+        CESU_8,
+        US_ASCII,
+        GB18030,
+        ISO_8859_2,
+        ISO_8859_3,
+        ISO_8859_4,
+        ISO_8859_5,
+        ISO_8859_6,
+        ISO_8859_7,
+        // IBM_813_P100_1995,  // Not supported by QTextCodec
+        ISO_8859_8,
+        // IBM_916_P100_1995,  // Not supported by QTextCodec
+        ISO_8859_9,
+        ISO_8859_10,
+        // ISO_8859_11_2001,   // Not supported by QTextCodec
+        ISO_8859_13,
+        ISO_8859_14,
+        // IBM_942_P12A_1999,  // Not supported by QTextCodec
+        Shift_JIS,
+        // IBM_943_P130_1999,  // Not supported by QTextCodec
+        // IBM_33722_P12A_P12A_2009_U2, // Not supported by QTextCodec
+        // IBM_33722_P120_1999, // Not supported by QTextCodec
+        // IBM_954_P101_2007,  // Not supported by QTextCodec
+        EUC_JP,
+        // IBM_1373_P100_2002, // Not supported by QTextCodec
+        Big5,
+        // IBM_950_P110_1999,  // Not supported by QTextCodec
+        Big5_HKSCS,
+        // IBM_5471_P100_2006, // Not supported by QTextCodec
+        // IBM_1386_P100_2001, // Not supported by QTextCodec
+        GBK,
+        GB2312,
+        /* GB_2312_80, => GB_2312-80 results in an infinite loop in ICU and
+         *  stalls the whole QJSEngine theads */
+        // EUC_TW_2014,        // Not supported by QTextCodec
+        // IBM_964_P110_1999,  // Not supported by QTextCodec
+        // IBM_949_P110_1999,  // Not supported by QTextCodec
+        // IBM_949_P11A_1999,  // Not supported by QTextCodec
+        EUC_KR,
+        /* IBM_971_P100_1995, => ibm-971_P100-1995 results in an infinite loop
+         * in ICU and stalls the whole QJSEngine theads */
+        CP1363,
+        // IBM_1363_P110_1997, // Not supported by QTextCodec
+        KSC_5601,
+        Windows_874_2000,
+        TIS_620,
+        // IBM_1162_P100_1999, // Not supported by QTextCodec
+        IBM437,
+        // IBM_720_P100_1997,  // Not supported by QTextCodec
+        // IBM_737_P100_1997,  // Not supported by QTextCodec
+        IBM775,
+        IBM850,
+        CP851,
+        IBM852,
+        IBM855,
+        // IBM_856_P100_1995,  // Not supported by QTextCodec
+        IBM857,
+        IBM00858,
+        IBM860,
+        IBM861,
+        IBM862,
+        IBM863,
+        IBM864,
+        IBM865,
+        IBM866,
+        // IBM_867_P100_1998,  // Not supported by QTextCodec
+        IBM868,
+        IBM869,
+        KOI8_R,
+        // IBM_901_P100_1999,  // Not supported by QTextCodec
+        // IBM_902_P100_1999,  // Not supported by QTextCodec
+        // IBM_922_P100_1999,  // Not supported by QTextCodec
+        KOI8_U,
+        // IBM_4909_P100_1999, // Not supported by QTextCodec
+        Windows_1250,
+        Windows_1251,
+        Windows_1252,
+        Windows_1253,
+        Windows_1254,
+        Windows_1255,
+        Windows_1256,
+        Windows_1257,
+        Windows_1258,
+        // IBM_1250_P100_1995, // Not supported by QTextCodec
+        // IBM_1251_P100_1995, // Not supported by QTextCodec
+        // IBM_1252_P100_2000, // Not supported by QTextCodec
+        // IBM_1253_P100_1995, // Not supported by QTextCodec
+        // IBM_1254_P100_1995, // Not supported by QTextCodec
+        // IBM_1255_P100_1995, // Not supported by QTextCodec
+        // IBM_5351_P100_1998, // Not supported by QTextCodec
+        // IBM_1256_P110_1997, // Not supported by QTextCodec
+        // IBM_5352_P100_1998, // Not supported by QTextCodec
+        // IBM_1257_P100_1995, // Not supported by QTextCodec
+        // IBM_5353_P100_1998, // Not supported by QTextCodec
+        // IBM_1258_P100_1997, // Not supported by QTextCodec
+        Macintosh,
+        X_Mac_Greek,
+        X_Mac_Cyrillic,
+        X_Mac_CentralEuroRoman,
+        X_Mac_Turkish,
+        HP_Roman8,
+        Adobe_Standard_Encoding,
+        // IBM_1006_P100_1995, // Not supported by QTextCodec
+        // IBM_1098_P100_1995, // Not supported by QTextCodec
+        // IBM_1124_P100_1996, // Not supported by QTextCodec
+        // IBM_1125_P100_1997, // Not supported by QTextCodec
+        // IBM_1129_P100_1997, // Not supported by QTextCodec
+        // IBM_1131_P100_1997, // Not supported by QTextCodec
+        // IBM_1133_P100_1997, // Not supported by QTextCodec
+        // GSM_03_38_2009,     // Not supported by QTextCodec
+        ISO_2022_JP,
+        ISO_2022_JP_1,
+        ISO_2022_JP_2,
+        // ISO_2022_Locale_JA_Version_3, // Not supported by QTextCodec
+        // ISO_2022_Locale_JA_Version_4, // Not supported by QTextCodec
+        ISO_2022_KR,
+        // ISO_2022_Locale_KO_Version_1, // Not supported by QTextCodec
+        ISO_2022_CN,
+        ISO_2022_CN_EXT,
+        // ISO_2022_Locale_ZH_Version_2, // Not supported by QTextCodec
+        HZ_GB_2312,
+        // X11_Compound_Text,  // Not supported by QTextCodec
+        // ISCII_Version_0,    // Not supported by QTextCodec
+        // ISCII_Version_1,    // Not supported by QTextCodec
+        // ISCII_Version_2,    // Not supported by QTextCodec
+        // ISCII_Version_3,    // Not supported by QTextCodec
+        // ISCII_Version_4,    // Not supported by QTextCodec
+        // ISCII_Version_5,    // Not supported by QTextCodec
+        // ISCII_Version_6,    // Not supported by QTextCodec
+        // ISCII_Version_7,    // Not supported by QTextCodec
+        // ISCII_Version_8,    // Not supported by QTextCodec
+        // LMBCS_1,            // Not supported by QTextCodec
+        IBM037,
+        IBM273,
+        IBM277,
+        IBM278,
+        IBM280,
+        IBM284,
+        IBM285,
+        IBM290,
+        IBM297,
+        IBM420,
+        IBM424,
+        IBM500,
+        // IBM_803_P100_1999,  // Not supported by QTextCodec
+        IBM_Thai,
+        IBM870,
+        IBM871,
+        // IBM_875_P100_1995,  // Not supported by QTextCodec
+        IBM918,
+        // IBM_930_P120_1999,  // Not supported by QTextCodec
+        // IBM_933_P110_1995,  // Not supported by QTextCodec
+        // IBM_935_P110_1999,  // Not supported by QTextCodec
+        // IBM_937_P110_1999,  // Not supported by QTextCodec
+        // IBM_939_P120_1999,  // Not supported by QTextCodec
+        // IBM_1025_P100_1995, // Not supported by QTextCodec
+        IBM1026,
+        IBM1047,
+        // IBM_1097_P100_1995, // Not supported by QTextCodec
+        // IBM_1112_P100_1995, // Not supported by QTextCodec
+        // IBM_1122_P100_1999, // Not supported by QTextCodec
+        // IBM_1123_P100_1995, // Not supported by QTextCodec
+        // IBM_1130_P100_1997, // Not supported by QTextCodec
+        // IBM_1132_P100_1998, // Not supported by QTextCodec
+        // IBM_1137_P100_1999, // Not supported by QTextCodec
+        // IBM_4517_P100_2005, // Not supported by QTextCodec
+        IBM01140,
+        IBM01141,
+        IBM01142,
+        IBM01143,
+        IBM01144,
+        IBM01145,
+        IBM01146,
+        IBM01147,
+        IBM01148,
+        IBM01149,
+        // IBM_1153_P100_1999, // Not supported by QTextCodec
+        // IBM_1154_P100_1999, // Not supported by QTextCodec
+        // IBM_1155_P100_1999, // Not supported by QTextCodec
+        // IBM_1156_P100_1999, // Not supported by QTextCodec
+        // IBM_1157_P100_1999, // Not supported by QTextCodec
+        // IBM_1158_P100_1999, // Not supported by QTextCodec
+        // IBM_1160_P100_1999, // Not supported by QTextCodec
+        // IBM_1164_P100_1999, // Not supported by QTextCodec
+        // IBM_1364_P110_2007, // Not supported by QTextCodec
+        // IBM_1371_P100_1999, // Not supported by QTextCodec
+        // IBM_1388_P103_2001, // Not supported by QTextCodec
+        // IBM_1390_P110_2003, // Not supported by QTextCodec
+        // IBM_1399_P110_2003, // Not supported by QTextCodec
+        // IBM_5123_P100_1999, // Not supported by QTextCodec
+        // IBM_8482_P100_1999, // Not supported by QTextCodec
+        /* IBM_16684_P110_2003, => ibm-16684_P110-2003 results in an infinite
+         * loop in ICU and stalls the whole QJSEngine theads // IBM_4899_P100_1998, */
+        // IBM_4971_P100_1999, // Not supported by QTextCodec
+        // IBM_9067_X100_2005, // Not supported by QTextCodec
+        // IBM_12712_P100_1998, // Not supported by QTextCodec
+        // IBM_16804_X110_1999, // Not supported by QTextCodec
+        // IBM_37_P100_1995_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1047_P100_1995_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1140_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1141_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1142_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1143_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1144_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1145_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1146_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1147_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1148_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1149_P100_1997_SwapLFNL, // Not supported by QTextCodec
+        // IBM_1153_P100_1999_SwapLFNL, // Not supported by QTextCodec
+        // IBM_12712_P100_1998_SwapLFNL, // Not supported by QTextCodec
+        // IBM_16804_X110_1999_SwapLFNL, // Not supported by QTextCodec
+        // EBCDIC_XML_US // Not supported by QTextCodec
     };
+
     Q_ENUM(WellKnownCharsets)
 
     ControllerScriptInterfaceLegacy(ControllerScriptEngineLegacy* m_pEngine,
@@ -87,8 +323,6 @@ class ControllerScriptInterfaceLegacy : public QObject {
                     targetCharset,
             const QString& value);
 
-    Q_INVOKABLE QByteArray convertCharset(const QString& targetCharset, const QString& value);
-
     bool removeScriptConnection(const ScriptConnection& conn);
     /// Execute a ScriptConnection's JS callback
     void triggerScriptConnection(const ScriptConnection& conn);
@@ -97,6 +331,7 @@ class ControllerScriptInterfaceLegacy : public QObject {
     virtual void timerEvent(QTimerEvent* event);
 
   private:
+    QByteArray convertCharsetInternal(const QString& targetCharset, const QString& value);
     QJSValue makeConnectionInternal(const QString& group,
             const QString& name,
             const QJSValue& callback,

--- a/src/test/controllerscriptenginelegacy_test.cpp
+++ b/src/test/controllerscriptenginelegacy_test.cpp
@@ -3,6 +3,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <QMetaEnum>
 #include <QScopedPointer>
 #include <QTemporaryFile>
 #include <QThread>
@@ -18,6 +19,7 @@
 #include "controllers/controllerenginethreadcontrol.h"
 #include "controllers/rendering/controllerrenderingengine.h"
 #endif
+#include "controllers/scripting/legacy/controllerscriptinterfacelegacy.h"
 #include "controllers/softtakeover.h"
 #include "helpers/log_test.h"
 #include "preferences/usersettings.h"
@@ -659,15 +661,79 @@ TEST_F(ControllerScriptEngineLegacyTest, connectionExecutesWithCorrectThisObject
     EXPECT_DOUBLE_EQ(1.0, pass->get());
 }
 
-TEST_F(ControllerScriptEngineLegacyTest, convertCharsetUndefinedOnUnknownCharset) {
-    const auto result = evaluate("engine.convertCharset('NULL', 'Hello!')");
-
-    EXPECT_EQ(qjsvalue_cast<QByteArray>(result), QByteArrayLiteral(""));
-}
-
 template<int N>
 QByteArray intByteArray(const char (&array)[N]) {
     return QByteArray(array, N);
+}
+
+TEST_F(ControllerScriptEngineLegacyTest, convertCharsetAllWellKnownCharsets) {
+    auto counter = std::make_unique<ControlObject>(ConfigKey("[Test]", "counter"));
+
+    QMetaEnum charsetEnumEntry = QMetaEnum::fromType<
+            ControllerScriptInterfaceLegacy::WellKnownCharsets>();
+
+    QString script = R"(
+        var workingCharsetCounter = 0;
+        var failedCharsets = [];
+        var expectedLengths = {
+            "UCS2": 68, "ISO_10646_UCS_2": 68, "UTF_16": 66, "UTF_16BE": 66, "UTF_16LE": 66,
+            "UTF_32": 128, "UTF_32BE": 128, "UTF_32LE": 128, "ISO_2022_KR": 54, "ISO_2022_Locale_KO_Version_1": 54,
+            "HZ_GB_2312": 49, "Latin1": 33, "ISO_8859_1": 33, "Latin9": 32, "ISO_8859_15": 32,
+            "UTF_8": 63, "UTF_7": 70, "SCSU": 51, "BOCU_1": 53, "CESU_8": 65, "US_ASCII": 32,
+            "GB18030": 69, "ISO_8859_2": 32, "ISO_8859_3": 32, "ISO_8859_4": 32, "ISO_8859_5": 32,
+            "ISO_8859_6": 32, "ISO_8859_7": 32, "ISO_8859_8": 32, "ISO_8859_9": 32, "ISO_8859_10": 32,
+            "ISO_8859_13": 32, "ISO_8859_14": 32, "Shift_JIS": 39, "EUC_JP": 39, "Big5": 34,
+            "Big5_HKSCS": 39, "GBK": 39, "GB2312": 39, "EUC_KR": 44, "CP1363": 44, "KSC_5601": 44,
+            "Windows_874_2000": 32, "TIS_620": 32, "IBM437": 32, "IBM775": 32, "IBM850": 32,
+            "CP851": 32, "IBM852": 32, "IBM855": 32, "IBM857": 32, "IBM00858": 32, "IBM860": 32,
+            "IBM861": 32, "IBM862": 32, "IBM863": 32, "IBM864": 32, "IBM865": 32, "IBM866": 32,
+            "IBM868": 32, "IBM869": 32, "KOI8_R": 32, "KOI8_U": 32, "Windows_1250": 32, "Windows_1251": 32,
+            "Windows_1252": 32, "Windows_1253": 32, "Windows_1254": 32, "Windows_1255": 32, "Windows_1256": 32,
+            "Windows_1257": 32, "Windows_1258": 32, "Macintosh": 32, "X_Mac_Greek": 32, "X_Mac_Cyrillic": 32,
+            "X_Mac_CentralEuroRoman": 32, "X_Mac_Turkish": 32, "HP_Roman8": 32, "Adobe_Standard_Encoding": 32,
+            "ISO_2022_JP": 51, "ISO_2022_JP_1": 51, "ISO_2022_JP_2": 63, "ISO_2022_CN": 47, "ISO_2022_CN_EXT": 47,
+            "IBM037": 32, "IBM273": 32, "IBM277": 32, "IBM278": 32, "IBM280": 32, "IBM284": 32,
+            "IBM285": 32, "IBM290": 32, "IBM297": 32, "IBM420": 32, "IBM424": 32, "IBM500": 32,
+            "IBM_Thai": 32, "IBM870": 32, "IBM871": 32, "IBM918": 32, "IBM1026": 32, "IBM1047": 32,
+            "IBM01140": 32, "IBM01141": 32, "IBM01142": 32, "IBM01143": 32, "IBM01144": 32, "IBM01145": 32,
+            "IBM01146": 32, "IBM01147": 32, "IBM01148": 32, "IBM01149": 32
+        };
+    )";
+
+    for (int i = 0; i < charsetEnumEntry.keyCount(); ++i) {
+        QString key = QString::fromUtf8(charsetEnumEntry.key(i));
+        script += QString(R"(
+            var charset = engine.WellKnownCharsets.%1;
+            var result = engine.convertCharset(charset, 'Hello, 世界! שלום! こんにちは! 안녕하세요! 😊');
+            var expectedLength = expectedLengths['%1'];
+            var resultLength = result.byteLength;
+            if (resultLength === expectedLength) {
+                workingCharsetCounter++;
+            } else {
+                failedCharsets.push(`Charset: %1  Result: ${result}  Result-Length: ${resultLength}  Expected-Length: ${expectedLength}`);
+            }
+        )")
+                          .arg(key);
+    }
+
+    script += R"(
+        engine.setValue('[Test]', 'counter', workingCharsetCounter);
+        failedCharsets.join('\n');
+    )";
+
+    QJSValue result = evaluate(script);
+    EXPECT_FALSE(result.isError());
+
+    QString failedCharsetsResult = result.toString();
+    if (!failedCharsetsResult.isEmpty()) {
+        ADD_FAILURE() << "Charsets with result length not equal to expected:\n"
+                      << failedCharsetsResult.toStdString();
+    }
+
+    // ControlObjectScript connections are processed via QueuedConnection. Use
+    // processEvents() to cause Qt to deliver them.
+    processEvents();
+    EXPECT_DOUBLE_EQ(counter->get(), charsetEnumEntry.keyCount());
 }
 
 TEST_F(ControllerScriptEngineLegacyTest, convertCharsetCorrectValueWellKnown) {
@@ -679,17 +745,9 @@ TEST_F(ControllerScriptEngineLegacyTest, convertCharsetCorrectValueWellKnown) {
             intByteArray({0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21}));
 }
 
-TEST_F(ControllerScriptEngineLegacyTest, convertCharsetCorrectValueStringCharset) {
-    const auto result = evaluate("engine.convertCharset('ISO-8859-15', 'Hello!')");
-
-    // ISO-8859-15 ecoded 'Hello!'
-    EXPECT_EQ(qjsvalue_cast<QByteArray>(result),
-            intByteArray({0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x21}));
-}
-
 TEST_F(ControllerScriptEngineLegacyTest, convertCharsetUnsupportedChars) {
     auto result = qjsvalue_cast<QByteArray>(
-            evaluate("engine.convertCharset('ISO-8859-15', 'مايأ نامز')"));
+            evaluate("engine.convertCharset(engine.WellKnownCharsets.ISO_8859_15, 'مايأ نامز')"));
 
     EXPECT_EQ(result,
             intByteArray(


### PR DESCRIPTION
- Expanded WellKnownCharsets enum in engine-api.d.ts and controllerscriptinterfacelegacy.h by all encodings that work with all supported Qt versions. I explicitly did not added three charsets, which triggered an infinite loop of the QJSEngine thread for me.
- Added a test case that tests the byte-length of the converted string for each of these charsets
- Made convertCharset function accepting string targetCharset private for safety reasons.
- Updated and added tests to ensure that we detect charsets that crash or result in unexpected output length.
- Added a deep copy of the targetcharset name reference
- Made encoder in Qt 6.4 case a self-deleting smart-pointer Optimize QAnyStringView handling for Qt >=6.8.0
- Improved error output
- Unified behavior of the UCS2 charsets between platforms by adding Byte Order Mark if missing