### PR TITLE
Made JS code containing the new engine.getPlayer API in controller_ma…

### DIFF
--- a/src/controllers/scripting/controllerscriptenginebase.cpp
+++ b/src/controllers/scripting/controllerscriptenginebase.cpp
@@ -35,12 +35,12 @@ void ControllerScriptEngineBase::registerPlayerManager(
     ControllerScriptEngineBase::s_pPlayerManager = pPlayerManager;
 }
 
-#ifdef MIXXX_USE_QML
 void ControllerScriptEngineBase::registerTrackCollectionManager(
         std::shared_ptr<TrackCollectionManager> pTrackCollectionManager) {
     s_pTrackCollectionManager = std::move(pTrackCollectionManager);
 }
 
+#ifdef MIXXX_USE_QML
 void ControllerScriptEngineBase::handleQMLErrors(const QList<QQmlError>& qmlErrors) {
     for (const QQmlError& error : std::as_const(qmlErrors)) {
         showQMLExceptionDialog(error, m_bErrorsAreFatal);

--- a/src/controllers/scripting/controllerscriptenginebase.h
+++ b/src/controllers/scripting/controllerscriptenginebase.h
@@ -16,9 +16,7 @@
 
 class Controller;
 class QJSEngine;
-#ifdef MIXXX_USE_QML
 class TrackCollectionManager;
-#endif
 
 /// ControllerScriptEngineBase manages the JavaScript engine for controller scripts.
 /// ControllerScriptModuleEngine implements the current system using JS modules.
@@ -59,10 +57,9 @@ class ControllerScriptEngineBase : public QObject {
 
     static void registerPlayerManager(std::shared_ptr<PlayerManager> pPlayerManager);
 
-#ifdef MIXXX_USE_QML
     static void registerTrackCollectionManager(
             std::shared_ptr<TrackCollectionManager> pTrackCollectionManager);
-#endif
+
   signals:
     void beforeShutdown();
 
@@ -99,9 +96,9 @@ class ControllerScriptEngineBase : public QObject {
 
   private:
     static inline std::shared_ptr<PlayerManager> s_pPlayerManager;
-#ifdef MIXXX_USE_QML
     static inline std::shared_ptr<TrackCollectionManager> s_pTrackCollectionManager;
 
+#ifdef MIXXX_USE_QML
   protected:
     /// Pause the GUI main thread. Pause is required by rendering
     /// thread (https://doc.qt.io/qt-6/qquickrendercontrol.html#sync). This

--- a/src/test/controller_mapping_validation_test.cpp
+++ b/src/test/controller_mapping_validation_test.cpp
@@ -8,7 +8,6 @@
 #include "controllers/defs_controllers.h"
 #include "controllers/scripting/legacy/controllerscriptenginelegacy.h"
 #include "track/track.h"
-#ifdef MIXXX_USE_QML
 #include "effects/effectsmanager.h"
 #include "engine/channelhandle.h"
 #include "engine/enginemixer.h"
@@ -16,10 +15,11 @@
 #include "library/library.h"
 #include "mixer/playerinfo.h"
 #include "mixer/playermanager.h"
+#ifdef MIXXX_USE_QML
 #include "qml/qmlplayermanagerproxy.h"
-#include "soundio/soundmanager.h"
 #endif
 #include "moc_controller_mapping_validation_test.cpp"
+#include "soundio/soundmanager.h"
 
 FakeMidiControllerJSProxy::FakeMidiControllerJSProxy()
         : ControllerJSProxy(nullptr) {
@@ -122,18 +122,10 @@ bool FakeController::isMappable() const {
     return false;
 }
 
-#ifdef MIXXX_USE_QML
-void deleteTrack(Track* pTrack) {
-    // Delete track objects directly in unit tests with
-    // no main event loop
-    delete pTrack;
-};
-#endif
-
 void LegacyControllerMappingValidationTest::SetUp() {
     m_mappingPath = getTestDir().filePath(QStringLiteral("../../res/controllers/"));
     m_pEnumerator.reset(new MappingInfoEnumerator(QList<QString>{m_mappingPath.absolutePath()}));
-#ifdef MIXXX_USE_QML
+
     // This setup mirrors coreservices -- it would be nice if we could use coreservices instead
     // but it does a lot of local disk / settings setup.
     auto pChannelHandleFactory = std::make_shared<ChannelHandleFactory>();
@@ -165,7 +157,7 @@ void LegacyControllerMappingValidationTest::SetUp() {
             nullptr,
             m_pConfig,
             dbConnectionPooler(),
-            deleteTrack);
+            [](Track* pTrack) { delete pTrack; });
 
     m_pRecordingManager = std::make_shared<RecordingManager>(m_pConfig, m_pEngine.get());
     CoverArtCache::createInstance();
@@ -178,16 +170,21 @@ void LegacyControllerMappingValidationTest::SetUp() {
             m_pRecordingManager.get());
 
     m_pPlayerManager->bindToLibrary(m_pLibrary.get());
+#ifdef MIXXX_USE_QML
     mixxx::qml::QmlPlayerManagerProxy::registerPlayerManager(m_pPlayerManager);
+#endif
+    ControllerScriptEngineBase::registerPlayerManager(m_pPlayerManager);
     ControllerScriptEngineBase::registerTrackCollectionManager(m_pTrackCollectionManager);
 }
 
 void LegacyControllerMappingValidationTest::TearDown() {
     PlayerInfo::destroy();
     CoverArtCache::destroy();
+#ifdef MIXXX_USE_QML
     mixxx::qml::QmlPlayerManagerProxy::registerPlayerManager(nullptr);
-    ControllerScriptEngineBase::registerTrackCollectionManager(nullptr);
 #endif
+    ControllerScriptEngineBase::registerPlayerManager(nullptr);
+    ControllerScriptEngineBase::registerTrackCollectionManager(nullptr);
 }
 
 bool LegacyControllerMappingValidationTest::testLoadMapping(const MappingInfo& mapping) {

--- a/src/test/controller_mapping_validation_test.h
+++ b/src/test/controller_mapping_validation_test.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <QObject>
-
 #include "control/controlindicatortimer.h"
 #include "controllers/controller.h"
 #include "controllers/controllermappinginfoenumerator.h"
@@ -222,7 +221,6 @@ class LegacyControllerMappingValidationTest : public MixxxDbTest, SoundSourcePro
 
   protected:
     void SetUp() override;
-#ifdef MIXXX_USE_QML
     void TearDown() override;
 
     TrackPointer getOrAddTrackByLocation(
@@ -239,7 +237,6 @@ class LegacyControllerMappingValidationTest : public MixxxDbTest, SoundSourcePro
     std::shared_ptr<TrackCollectionManager> m_pTrackCollectionManager;
     std::shared_ptr<RecordingManager> m_pRecordingManager;
     std::shared_ptr<Library> m_pLibrary;
-#endif
 
     bool testLoadMapping(const MappingInfo& mapping);
 


### PR DESCRIPTION
Made JS code containing the new engine.getPlayer API in controller_mapping_validation_test and controllerscriptenginelegacy_test executable without crash
This does not yet implement a test itself, but allows to load tracks into decks as in playermanagertest and makes controller_mapping_validation_test working if QML is not enabled.